### PR TITLE
🔀 :: [#4] Moya 의존성 추가 및 CI 세팅

### DIFF
--- a/.github/workflows/Washer_CI.yml
+++ b/.github/workflows/Washer_CI.yml
@@ -1,0 +1,49 @@
+name: Washer CI
+
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "*" ]
+
+jobs:
+  CI:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '5.9'
+
+      - name: Build Project
+        run: swift build
+
+      - name: Send Success Notification to Discord
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ success() }}
+        with:
+          title: CI 성공!
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 성공
+          image: ${{ secrets.CI_SUCCESS_IMAGE }}
+          description: CI가 성공적으로 완료되었습니다.
+          color: 00FF00
+          username: CI Bot
+          url: https://github.com/team-washer/Washer-iOS
+
+      - name: Send Failure Notification to Discord
+        uses: sarisia/actions-status-discord@v1
+        if: ${{ failure() }}
+        with:
+          title: CI 실패!
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: 실패
+          image: ${{ secrets.CI_FAIL_IMAGE }}
+          description: CI가 실패했습니다. 로그를 확인해주세요.
+          color: FF0000
+          username: CI Bot
+          url: https://github.com/team-washer/Washer-iOS

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
+      }
+    },
+    {
+      "identity" : "moya",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Moya/Moya.git",
+      "state" : {
+        "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
+        "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "5dd1907d64f0d36f158f61a466bab75067224893",
+        "version" : "6.9.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ import PackageDescription
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-@MainActor
 let packageSetting = PackageSettings(
     baseSettings: .settings(
         configurations: [
@@ -17,7 +16,6 @@ let packageSetting = PackageSettings(
 )
 #endif
 
-@MainActor
 let package = Package(
     name: "Package",
     dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 import ProjectDescription
 import ProjectDescriptionHelpers
 
+@MainActor
 let packageSetting = PackageSettings(
     baseSettings: .settings(
         configurations: [
@@ -16,7 +17,10 @@ let packageSetting = PackageSettings(
 )
 #endif
 
+@MainActor
 let package = Package(
     name: "Package",
-    dependencies: []
+    dependencies: [
+        .package(url: "https://github.com/Moya/Moya.git", from: "15.0.0")
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 import PackageDescription
 
 #if TUIST

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -4,7 +4,9 @@ public extension TargetDependency {
     struct SPM {}
 }
 
+@MainActor
 public extension TargetDependency.SPM {
+    static let Moya = TargetDependency.external(name: "Moya")
 }
 
 public extension Package {

--- a/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
+++ b/Plugin/DependencyPlugin/ProjectDescriptionHelpers/Dependency+SPM.swift
@@ -4,7 +4,6 @@ public extension TargetDependency {
     struct SPM {}
 }
 
-@MainActor
 public extension TargetDependency.SPM {
     static let Moya = TargetDependency.external(name: "Moya")
 }

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -5,16 +5,20 @@ import Foundation
 import ProjectDescription
 import ProjectDescriptionHelpers
 
+@MainActor
 let configurations: [Configuration] = .default
 
+@MainActor
 let settings: Settings = .settings(
     base: env.baseSetting,
     configurations: configurations,
     defaultSettings: .recommended
 )
 
+@MainActor
 let scripts: [TargetScript] = generateEnvironment.scripts
 
+@MainActor
 let targets: [Target] = [
     .target(
         name: env.name,
@@ -26,11 +30,14 @@ let targets: [Target] = [
         sources: ["Sources/**"],
         resources: ["Resources/**"],
         scripts: scripts,
-        dependencies: [],
+        dependencies: [
+            .SPM.Moya
+        ],
         settings: .settings(base: env.baseSetting)
     )
 ]
 
+@MainActor
 let schemes: [Scheme] = [
     .scheme(
         name: "\(env.name)-DEV",
@@ -61,6 +68,7 @@ let schemes: [Scheme] = [
     )
 ]
 
+@MainActor
 let project = Project(
     name: env.name,
     organizationName: env.organizationName,

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -5,17 +5,14 @@ import Foundation
 import ProjectDescription
 import ProjectDescriptionHelpers
 
-@MainActor
 let configurations: [Configuration] = .default
 
-@MainActor
 let settings: Settings = .settings(
     base: env.baseSetting,
     configurations: configurations,
     defaultSettings: .recommended
 )
 
-@MainActor
 let scripts: [TargetScript] = generateEnvironment.scripts
 
 @MainActor
@@ -37,7 +34,6 @@ let targets: [Target] = [
     )
 ]
 
-@MainActor
 let schemes: [Scheme] = [
     .scheme(
         name: "\(env.name)-DEV",
@@ -68,7 +64,6 @@ let schemes: [Scheme] = [
     )
 ]
 
-@MainActor
 let project = Project(
     name: env.name,
     organizationName: env.organizationName,


### PR DESCRIPTION
## 💡 개요
### Moya 의존성 추가 및 CI 세팅

## 📃 작업내용
Moya 의존성을 Tuist에 주입하여 서버 통신을 위한 세팅을 합니다.
CI를 추가하여 PR이 올라갈 때 마다 코드와 파일의 문제를 확인합니다.

